### PR TITLE
Make vim-tidal work with Tidal 0.5.

### DIFF
--- a/BootTidal.hss
+++ b/BootTidal.hss
@@ -2,19 +2,18 @@
 
 :module Sound.Tidal.Context
 
-let newStream = stream "127.0.0.1" 7771 dirt
-
-d1 <- newStream
-d2 <- newStream
-d3 <- newStream
-d4 <- newStream
-d5 <- newStream
-d6 <- newStream
-d7 <- newStream
-d8 <- newStream
-d9 <- newStream
-
 (cps, getNow) <- bpsUtils
+
+(d1,t1) <- dirtSetters getNow
+(d2,t2) <- dirtSetters getNow
+(d3,t3) <- dirtSetters getNow
+(d4,t4) <- dirtSetters getNow
+(d5,t5) <- dirtSetters getNow
+(d6,t6) <- dirtSetters getNow
+(d7,t7) <- dirtSetters getNow
+(d8,t8) <- dirtSetters getNow
+(d9,t9) <- dirtSetters getNow
+(d10,t10) <- dirtSetters getNow
 
 let bps x = cps (x/2)
 let hush = mapM_ ($ silence) [d1,d2,d3,d4,d5,d6,d7,d8,d9]


### PR DESCRIPTION
Make vim-tidal work with the new features in Tidal 0.5.
Have to say it will break the old Tidal versions :(.