### PR TITLE
Dirt-Samples dictionary completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.dirt-samples

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ These are some of the commands that can be run from Vim command line:
 
 * `:TidalHush`: Silences all streams by sending `hush`.
 
+* `:TidalGenerateCompletions {path}`: Generate dictionary for Dirt-Samples completion (path is optional)
+
 ### Default bindings
 
 Using one of these key bindings you can send lines to Tidal:

--- a/bin/generate-completions
+++ b/bin/generate-completions
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+samplepath=$1
+outputpath=$2
+
+ls "$samplepath" | sed 's/README.md//; s/Dirt-Samples.quark//;' | sed '/^\s*$/d' > "$outputpath"

--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -166,6 +166,8 @@ function! s:TidalRestoreCurPos()
   endif
 endfunction
 
+let s:parent_path = fnamemodify(expand("<sfile>"), ":p:h:s?/plugin??")
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Public interface
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -210,6 +212,26 @@ function! s:TidalPlay(stream)
   endif
 endfunction
 
+function! s:TidalGenerateCompletions(path)
+  let l:exe = s:parent_path . "/bin/generate-completions"
+  let l:output_path = s:parent_path . "/.dirt-samples"
+
+  if !empty(a:path)
+    let l:sample_path = a:path
+  else
+    if has('macunix')
+      let l:sample_path = "~/Library/Application Support/SuperCollider/downloaded-quarks/Dirt-Samples"
+    elseif has('unix')
+      let l:sample_path = "~/.local/share/SuperCollider/downloaded-quarks/Dirt-Samples"
+    endif
+  endif
+  " generate completion file
+  silent execute '!' . l:exe shellescape(expand(l:sample_path)) shellescape(expand(l:output_path))
+  echo "Generated dictionary of dirt-samples"
+  " setup completion
+  let &l:dictionary .= ',' . l:output_path
+endfunction
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Setup key bindings
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -221,6 +243,7 @@ command -nargs=+ TidalSend1 call s:TidalSend(<q-args> . "\r")
 command! -nargs=0 TidalHush call s:TidalHush()
 command! -nargs=1 TidalSilence call s:TidalSilence(<args>)
 command! -nargs=1 TidalPlay call s:TidalPlay(<args>)
+command! -nargs=? TidalGenerateCompletions call s:TidalGenerateCompletions(<q-args>)
 
 noremap <SID>Operator :<c-u>call <SID>TidalStoreCurPos()<cr>:set opfunc=<SID>TidalSendOp<cr>g@
 
@@ -252,3 +275,7 @@ end
 if !exists("g:tidal_flash_duration")
   let g:tidal_flash_duration = 150
 end
+
+if filereadable(s:parent_path . "/.dirt-samples")
+  let &l:dictionary .= ',' . s:parent_path . "/.dirt-samples"
+endif


### PR DESCRIPTION
Hi!

This PR enables dictionary completion for SuperDirt samples.

It adds a new command `:TidalGenerateCompletions` that generates a file which contains a list of all the SuperDirt sample folders, and sets that file to be used for dictionary completion in vim. This provides a convenient way to find, and cycle through, available samples using `^x^k` (and auto-completion of samples if the user has such a plugin installed)

The `TidalGenerateCompletions` command will use the default installation paths for SuperCollider quarks to find the sample files. It is also possible to override this behaviour by supplying a path to the command pointing to another sample folder.

I have tested this on OS X 10.9.5, and I have provided a path for linux where I believe the samples are installed. I'm not sure if this plugin works on windows (?), but if that is the case it should be easy to add a samples path for windows as well. 

I have kept the commit history as it is for easier reviewing, but I could squash everything into a single commit if you are interested in merging this feature. 